### PR TITLE
Fix segfault on player logout with party bots

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4577,6 +4577,16 @@ void Player::SpawnPlayerLootCrate()
 
     // Hardcore Mode: Spawn a loot crate at player's death location
 
+    if (!sWorld.getConfig(CONFIG_BOOL_HARDCORE_MODE_ENABLED))
+        return;
+
+    // Don't spawn loot crates during logout teardown (LogoutPlayer → BuildPlayerRepop
+    // → CreateCorpse). DestroyItem inside this function can trigger reactive damage
+    // (thorns/shields) which re-enters DealDamageMods and iterates group members that
+    // may have already been freed earlier in the same LogoutAllBots loop.
+    if (GetSession()->isLogingOut())
+        return;
+
     // Money bag
     const uint32 LOOT_CRATE_ENTRY = 186736;
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -883,8 +883,16 @@ void Unit::DealDamageMods(Unit* dealer, Unit* victim, uint32& damage, uint32* ab
         victim->AI()->DamageTaken(dealer, damage, damagetype, spellInfo);
 
 #ifdef ENABLE_PLAYERBOTS
-    if (dealer && damage > 0)
+    // Only track actual player-vs-player damage for PvP attacker lists.
+    // Firing on all damage (PvE, aura removal, item teardown) causes
+    // group-member iteration during logout teardown when Player objects
+    // in the same group have already been freed — use-after-free / segfault.
+    if (dealer && damage > 0 && victim->IsPlayer() &&
+        (dealer->IsPlayer() || (dealer->GetOwner() && dealer->GetOwner()->IsPlayer()) ||
+         (dealer->GetCharmer() && dealer->GetCharmer()->IsPlayer())))
+    {
         ai::RecordRecentPvpAttacker(victim, dealer);
+    }
 #endif
 
     if (absorb && originalDamage > damage)


### PR DESCRIPTION
## Problem

Server segfaults when a player with party bots logs out. The crash occurs at the moment the 20-second logout timer expires.

## Root Cause

Two issues in our custom code:

1. `RecordRecentPvpAttacker` in `DealDamageMods` fired on ALL damage (PvE, aura removal, item teardown -- not just PvP). During `LogoutAllBots`, bot Player objects are deleted one-by-one while the group's member slots still reference them. If any reactive damage (thorns, damage shields) triggers during `DestroyItem` inside `SpawnPlayerLootCrate`, the hook re-enters `DealDamageMods`, iterates group members, and accesses freed memory -- segfault.

2. `SpawnPlayerLootCrate` ran unconditionally during logout teardown. `LogoutPlayer` -> `BuildPlayerRepop` -> `CreateCorpse` calls `SpawnPlayerLootCrate`, which calls `DestroyItem` in a loop. This is the trigger for the reactive-damage re-entry above.

## Fixes

- `Unit.cpp`: Narrow the `DealDamageMods` hook to only fire when both sides resolve to a player (direct hit, pet owner, or charmer). Eliminates all spurious calls from PvE/aura/environmental/item-teardown damage.

- `Player.cpp`: Add two early-return guards in `SpawnPlayerLootCrate`:
  - Skip if hardcore mode is not enabled (was missing entirely)
  - Skip if the session is in logout teardown (`isLogingOut()`)

## Testing

Reproduce: create a party with bots, sit on the road outside a rest area, initiate logout, wait for timer to expire. Server should no longer crash.
