### PR TITLE
[codex] Harden launcher release reputation

### DIFF
--- a/.github/workflows/rusty-mangos-launcher.yml
+++ b/.github/workflows/rusty-mangos-launcher.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install Boost
+        shell: pwsh
+        run: choco install boost-msvc-14.3 -y --no-progress
+
       - name: Build launcher installer
         shell: pwsh
         run: .\scripts\package-rusty-mangos-launcher.ps1
@@ -59,6 +63,13 @@ jobs:
           path: target\launcher-package\app
           if-no-files-found: error
 
+      - name: Upload checksums
+        uses: actions/upload-artifact@v6
+        with:
+          name: RustyMangosChecksums
+          path: target\launcher-package\installer\SHA256SUMS.txt
+          if-no-files-found: error
+
       - name: Zip packaged app for release
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         shell: pwsh
@@ -67,6 +78,10 @@ jobs:
             -Path target\launcher-package\app\* `
             -DestinationPath target\launcher-package\installer\RustyMangosApp.zip `
             -Force
+          $hash = Get-FileHash -LiteralPath target\launcher-package\installer\RustyMangosApp.zip -Algorithm SHA256
+          Add-Content `
+            -LiteralPath target\launcher-package\installer\SHA256SUMS.txt `
+            -Value ("{0}  {1}" -f $hash.Hash.ToLowerInvariant(), "RustyMangosApp.zip")
 
       - name: Publish rolling launcher release
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -94,6 +109,7 @@ jobs:
           gh release create $tag `
             "target\launcher-package\installer\RustyMangosSetup.exe#RustyMangosSetup.exe" `
             "target\launcher-package\installer\RustyMangosApp.zip#RustyMangosApp.zip" `
+            "target\launcher-package\installer\SHA256SUMS.txt#SHA256SUMS.txt" `
             --repo $env:GITHUB_REPOSITORY `
             --target $env:GITHUB_SHA `
             --title $title `

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -1263,7 +1263,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -3143,7 +3143,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3208,6 +3208,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "winresource",
 ]
 
 [[package]]
@@ -3317,6 +3318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4033,9 +4043,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4064,7 +4089,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -4096,6 +4121,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -5068,6 +5099,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml 1.1.2+spec-1.1.0",
+ "version_check",
 ]
 
 [[package]]

--- a/bins/rusty-mangos-launcher/Cargo.toml
+++ b/bins/rusty-mangos-launcher/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rusty-mangos-launcher"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [[bin]]
 name = "rusty-mangos-launcher"
@@ -13,3 +14,6 @@ egui = "0.31"
 rfd = "0.15"
 serde = { workspace = true }
 serde_json = "1"
+
+[build-dependencies]
+winresource = "0.1"

--- a/bins/rusty-mangos-launcher/build.rs
+++ b/bins/rusty-mangos-launcher/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_none() {
+        return;
+    }
+
+    let version = env!("CARGO_PKG_VERSION");
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        .set("FileDescription", "Rusty MaNGOS Launcher")
+        .set("ProductName", "Rusty MaNGOS")
+        .set("CompanyName", "Rusty MaNGOS")
+        .set("InternalName", "RustyMangosLauncher")
+        .set("OriginalFilename", "RustyMangosLauncher.exe")
+        .set("LegalCopyright", "Rusty MaNGOS contributors")
+        .set("ProductVersion", version)
+        .set("FileVersion", version);
+
+    if let Err(error) = resource.compile() {
+        panic!("compile Windows launcher resource: {error}");
+    }
+}

--- a/bins/rusty-mangos-launcher/src/main.rs
+++ b/bins/rusty-mangos-launcher/src/main.rs
@@ -517,7 +517,7 @@ impl LauncherApp {
         let mut args = vec![
             "-NoProfile".to_string(),
             "-ExecutionPolicy".to_string(),
-            "Bypass".to_string(),
+            "RemoteSigned".to_string(),
             "-File".to_string(),
             paths.script.display().to_string(),
             action.to_string(),

--- a/docs/rusty_mangos_launcher.md
+++ b/docs/rusty_mangos_launcher.md
@@ -122,6 +122,39 @@ downloads the official Inno Setup installer and installs the compiler into
 `target\tooling\inno-setup`. This is build-machine tooling only; players only
 run `RustyMangosSetup.exe`.
 
+## Antivirus Reputation
+
+Unsigned game launchers are frequently flagged by reputation-based scanners,
+especially when they start hidden helper processes, download dependencies, edit
+game configuration, run PowerShell, or self-update. Those behaviors are normal
+for this launcher, but they also overlap with common malware heuristics.
+
+Before sharing public builds:
+
+- build on GitHub Actions or another clean, reproducible machine;
+- sign `RustyMangosLauncher.exe`, `authserver.exe`, `worldserver.exe`, and
+  `RustyMangosSetup.exe` with an Authenticode code-signing certificate;
+- publish the generated `SHA256SUMS.txt` next to the installer;
+- submit the signed installer to Microsoft Security Intelligence if Defender
+  still reports a false positive;
+- avoid repacking the installer with third-party compressors or wrapper tools.
+
+The packaging script signs automatically when either `RUSTY_MANGOS_SIGN_PFX`
+or `RUSTY_MANGOS_SIGN_CERT_SHA1` is set:
+
+```powershell
+$env:RUSTY_MANGOS_SIGN_PFX = "C:\certs\rusty-mangos-signing.pfx"
+$env:RUSTY_MANGOS_SIGN_PFX_PASSWORD = "<password>"
+.\scripts\package-rusty-mangos-launcher.ps1
+```
+
+For a certificate installed in the Windows certificate store:
+
+```powershell
+$env:RUSTY_MANGOS_SIGN_CERT_SHA1 = "<certificate-thumbprint>"
+.\scripts\package-rusty-mangos-launcher.ps1
+```
+
 ## Useful Options
 
 ```powershell

--- a/installer/RustyMangos.iss
+++ b/installer/RustyMangos.iss
@@ -8,6 +8,9 @@ AppId={{E174BC31-598D-4CB7-9C91-2F17161CE255}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}
+AppPublisherURL=https://github.com/subhei999/rusty-mangos
+AppSupportURL=https://github.com/subhei999/rusty-mangos/issues
+AppUpdatesURL=https://github.com/subhei999/rusty-mangos/releases
 DefaultDirName={autopf}\Rusty MaNGOS
 DefaultGroupName=Rusty MaNGOS
 DisableProgramGroupPage=yes
@@ -18,6 +21,12 @@ SolidCompression=yes
 WizardStyle=modern
 ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=lowest
+SetupLogging=yes
+VersionInfoCompany={#MyAppPublisher}
+VersionInfoDescription=Rusty MaNGOS Launcher Setup
+VersionInfoProductName={#MyAppName}
+VersionInfoProductVersion={#MyAppVersion}
+VersionInfoVersion={#MyAppVersion}
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/scripts/package-rusty-mangos-launcher.ps1
+++ b/scripts/package-rusty-mangos-launcher.ps1
@@ -2,7 +2,12 @@ param(
     [switch]$SkipRustBuild,
     [switch]$SkipInstaller,
     [string]$ExtractorSourcePath,
-    [string]$InnoSetupUrl = "https://jrsoftware.org/download.php/is.exe"
+    [string]$InnoSetupUrl = "https://jrsoftware.org/download.php/is.exe",
+    [string]$SignToolPath,
+    [string]$SignCertSha1 = $env:RUSTY_MANGOS_SIGN_CERT_SHA1,
+    [string]$SignPfxPath = $env:RUSTY_MANGOS_SIGN_PFX,
+    [string]$SignPfxPassword = $env:RUSTY_MANGOS_SIGN_PFX_PASSWORD,
+    [string]$TimestampUrl = "http://timestamp.digicert.com"
 )
 
 $ErrorActionPreference = "Stop"
@@ -16,6 +21,85 @@ function Invoke-Checked {
     & $Command @Arguments
     if ($LASTEXITCODE -ne 0) {
         throw "$Command $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-SignTool {
+    if (-not [string]::IsNullOrWhiteSpace($SignToolPath)) {
+        $resolved = Resolve-Path -LiteralPath $SignToolPath -ErrorAction SilentlyContinue
+        if (-not $resolved) {
+            throw "SignToolPath does not exist: $SignToolPath"
+        }
+        return $resolved.ProviderPath
+    }
+
+    $pathTool = Get-Command signtool.exe -ErrorAction SilentlyContinue
+    if ($pathTool) {
+        return $pathTool.Source
+    }
+
+    $kitsRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    if (Test-Path -LiteralPath $kitsRoot -PathType Container) {
+        $tool = Get-ChildItem -LiteralPath $kitsRoot -Filter signtool.exe -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+        if ($tool) {
+            return $tool.FullName
+        }
+    }
+
+    throw "signtool.exe was not found. Install the Windows SDK or pass -SignToolPath."
+}
+
+function Invoke-AuthenticodeSign {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($SignCertSha1) -and [string]::IsNullOrWhiteSpace($SignPfxPath)) {
+        return
+    }
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "Cannot sign missing file: $Path"
+    }
+
+    $signtool = Get-SignTool
+    $arguments = @("sign", "/fd", "SHA256", "/tr", $TimestampUrl, "/td", "SHA256")
+    if (-not [string]::IsNullOrWhiteSpace($SignPfxPath)) {
+        $pfx = Resolve-Path -LiteralPath $SignPfxPath -ErrorAction SilentlyContinue
+        if (-not $pfx) {
+            throw "PFX signing certificate does not exist: $SignPfxPath"
+        }
+        $arguments += @("/f", $pfx.ProviderPath)
+        if (-not [string]::IsNullOrWhiteSpace($SignPfxPassword)) {
+            $arguments += @("/p", $SignPfxPassword)
+        }
+    }
+    else {
+        $arguments += @("/sha1", $SignCertSha1)
+    }
+    $arguments += $resolved.ProviderPath
+
+    Invoke-Checked $signtool $arguments
+}
+
+function Write-Sha256Manifest {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Paths,
+        [Parameter(Mandatory = $true)][string]$OutputPath
+    )
+
+    $lines = foreach ($path in $Paths) {
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            $hash = Get-FileHash -LiteralPath $path -Algorithm SHA256
+            $name = Split-Path -Leaf $path
+            "{0}  {1}" -f $hash.Hash.ToLowerInvariant(), $name
+        }
+    }
+
+    if ($lines) {
+        Set-Content -LiteralPath $OutputPath -Value $lines -Encoding ASCII
     }
 }
 
@@ -158,6 +242,10 @@ New-Item -ItemType Directory -Force -Path (Join-Path $appRoot "server") | Out-Nu
 Copy-Item -LiteralPath "target\release\authserver.exe" -Destination (Join-Path $appRoot "server\authserver.exe") -Force
 Copy-Item -LiteralPath "target\release\worldserver.exe" -Destination (Join-Path $appRoot "server\worldserver.exe") -Force
 
+Invoke-AuthenticodeSign (Join-Path $appRoot "RustyMangosLauncher.exe")
+Invoke-AuthenticodeSign (Join-Path $appRoot "server\authserver.exe")
+Invoke-AuthenticodeSign (Join-Path $appRoot "server\worldserver.exe")
+
 $commit = (& git rev-parse HEAD).Trim()
 $branch = (& git rev-parse --abbrev-ref HEAD).Trim()
 $remote = ((& git config --get remote.origin.url 2>$null) -join "").Trim()
@@ -225,10 +313,23 @@ New-Item -ItemType Directory -Force -Path (Join-Path $appRoot "sql\updates\mango
 Copy-Item -Path "sql\updates\mangos\*.sql" -Destination (Join-Path $appRoot "sql\updates\mangos") -Force
 
 if ($SkipInstaller) {
+    Write-Sha256Manifest @(
+        (Join-Path $appRoot "RustyMangosLauncher.exe"),
+        (Join-Path $appRoot "server\authserver.exe"),
+        (Join-Path $appRoot "server\worldserver.exe")
+    ) (Join-Path $packageRoot "SHA256SUMS.txt")
     Write-Host "Packaged app folder: $appRoot"
     exit 0
 }
 
 $iscc = Get-InnoCompiler $repoRoot
 Invoke-Checked $iscc @("installer\RustyMangos.iss")
-Write-Host "Installer output: $(Join-Path $packageRoot 'installer\RustyMangosSetup.exe')"
+$installerPath = Join-Path $packageRoot "installer\RustyMangosSetup.exe"
+Invoke-AuthenticodeSign $installerPath
+Write-Sha256Manifest @(
+    $installerPath,
+    (Join-Path $appRoot "RustyMangosLauncher.exe"),
+    (Join-Path $appRoot "server\authserver.exe"),
+    (Join-Path $appRoot "server\worldserver.exe")
+) (Join-Path $packageRoot "installer\SHA256SUMS.txt")
+Write-Host "Installer output: $installerPath"

--- a/scripts/rusty-mangos-launcher.cmd
+++ b/scripts/rusty-mangos-launcher.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0rusty-mangos-launcher.ps1" %*
+powershell -NoProfile -ExecutionPolicy RemoteSigned -File "%~dp0rusty-mangos-launcher.ps1" %*

--- a/scripts/rusty-mangos-launcher.ps1
+++ b/scripts/rusty-mangos-launcher.ps1
@@ -1399,7 +1399,7 @@ while (Get-Process -Id $LauncherPid -ErrorAction SilentlyContinue) {
 
 $launcherScript = Join-Path $AppRoot "scripts\rusty-mangos-launcher.ps1"
 if (Test-Path -LiteralPath $launcherScript -PathType Leaf) {
-    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $launcherScript Stop | Out-Null
+    & powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File $launcherScript Stop | Out-Null
 }
 
 Get-ChildItem -LiteralPath $StageRoot -Force | ForEach-Object {
@@ -1415,7 +1415,7 @@ Start-Process -FilePath (Join-Path $AppRoot "RustyMangosLauncher.exe") -WorkingD
     Start-Process -FilePath "powershell.exe" -ArgumentList @(
         "-NoProfile",
         "-ExecutionPolicy",
-        "Bypass",
+        "RemoteSigned",
         "-File",
         $helperPath,
         "-LauncherPid",


### PR DESCRIPTION
## Summary

This tightens the Windows launcher release path so public builds look less like low-reputation malware to AV heuristics while keeping behavior transparent.

- Embed Windows version/resource metadata in `RustyMangosLauncher.exe`.
- Replace launcher package PowerShell `ExecutionPolicy Bypass` usage with `RemoteSigned`.
- Add optional Authenticode signing support for launcher/server/installer artifacts.
- Generate and publish SHA-256 manifests for release artifacts.
- Add installer publisher/support/update metadata and document the AV reputation checklist.

## Why

The launcher does legitimate but suspicious-looking things: it starts hidden helper processes, runs PowerShell, downloads dependencies, edits client configuration, and self-updates. Unsigned binaries plus those behaviors can trigger reputation-based false positives.

## Validation

- `cargo check -p rusty-mangos-launcher`
- `cargo fmt -p rusty-mangos-launcher -- --check`
- PowerShell parser checks for `scripts/package-rusty-mangos-launcher.ps1` and `scripts/rusty-mangos-launcher.ps1`
- `git diff --check` on the staged launcher/package changes

Known: full `./scripts/test-rust.cmd` currently stops at `cargo fmt --check` in pre-existing dirty gameplay files outside this launcher package change.